### PR TITLE
Added NuGet package version to example

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ These are a work-in-progress; feel free to raise an issue if you have questions 
 To install the templates, run:
 
 ```
-dotnet new -i FiftyProtons.Templates.DotNetNew
+dotnet new -i FiftyProtons.Templates.DotNetNew::0.1.0-alpha1
 ```
 
 # Run from source


### PR DESCRIPTION
Fixed with explicit mention to version.

Normal syntax would be `dotnet new -i FiftyProtons.Templates.DotNetNew::*` to pick latest version.

Since, [according to NuGet](https://www.nuget.org/packages/FiftyProtons.Templates.DotNetNew), there is no package that is not in pre-release, we need to specify the version `dotnet new -i FiftyProtons.Templates.DotNetNew::0.1.0-alpha1`