### PR TITLE
Add a template pack packaging project

### DIFF
--- a/src/Templates/content/TemplatePackagingProject/.template.config/template.json
+++ b/src/Templates/content/TemplatePackagingProject/.template.config/template.json
@@ -1,0 +1,24 @@
+{
+  "author": "Adam Friedman (tintoy@tintoy.io)",
+  "classifications": [
+    "Common",
+    "Templates",
+    "Packaging"
+  ],
+  "name": "Template packaging template",
+  "identity": "FiftyProtons.PackagingProject",
+  "groupIdentity": "FiftyProtons.Templates.PackagingProject",
+  "shortName": "packaging-template",
+  "tags": {
+    "language": "C#",
+    "type": "project"
+  },
+  "sourceName": "PackagingTemplate",
+  "guids": [],
+  "preferNameDirectory": true,
+  "primaryOutputs": [
+    {
+      "path": "PackagingTemplate.proj"
+    }
+  ]
+}

--- a/src/Templates/content/TemplatePackagingProject/PackagingTemplate.proj
+++ b/src/Templates/content/TemplatePackagingProject/PackagingTemplate.proj
@@ -1,0 +1,28 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup Label="TemplatePackInfo">
+    <Authors>Your name here</Authors>
+    <Description>A description for your template pack</Description>
+    <Version>1.0.0</Version>
+  </PropertyGroup>
+
+  <PropertyGroup Label="PackageConfiguration">
+    <TargetFramework>netstandard1.0</TargetFramework>
+    <PackageType>Template</PackageType>
+    <ExcludeFromPackage>
+      **/bin/**;
+      **/obj/**
+    </ExcludeFromPackage>
+  </PropertyGroup>
+
+  <PropertyGroup Label="BuildConfiguration">
+    <NoBuild>True</NoBuild>
+    <IncludeBuildOutput>False</IncludeBuildOutput>
+    <GenerateAssemblyInfo>False</GenerateAssemblyInfo>
+    <DisableImplicitFrameworkReferences>True</DisableImplicitFrameworkReferences>
+    <PackProjectInputFile>$(MSBuildProjectFullPath)</PackProjectInputFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Content Include="content/**/*" Exclude="$(ExcludeFromPackage)" PackagePath="Content/" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
This just drops a project that `dotnet pack` can be called on the produce a nuget package for a pack of templates.

As long as the templates are placed within the `content` folder that gets included in the template, they'll be included in the nupkg

Fixes https://github.com/dotnet/templating/issues/954